### PR TITLE
Real-world changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 
 # IDE files
 /.idea
+constants.ts.*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+FROM node:16-alpine AS node
+FROM node AS node-with-gyp
+RUN apk add g++ make python3
+FROM node-with-gyp AS builder
+WORKDIR /squid
+ADD package.json .
+ADD package-lock.json .
+# remove if needed
+ADD assets assets 
+# remove if needed
+ADD db db
+# remove if needed
+ADD schema.graphql .
+RUN npm ci
+ADD tsconfig.json .
+ADD src src
+RUN npm run build
+FROM node-with-gyp AS deps
+WORKDIR /squid
+ADD package.json .
+ADD package-lock.json .
+RUN npm ci --production
+FROM node AS squid
+WORKDIR /squid
+COPY --from=deps /squid/package.json .
+COPY --from=deps /squid/package-lock.json .
+COPY --from=deps /squid/node_modules node_modules
+COPY --from=builder /squid/lib lib
+# remove if no assets folder
+COPY --from=builder /squid/assets assets
+# remove if no db folder
+COPY --from=builder /squid/db db
+# remove if no schema.graphql is in the root
+COPY --from=builder /squid/schema.graphql schema.graphql
+# remove if no commands.json is in the root
+ADD commands.json .
+RUN echo -e "loglevel=silent\\nupdate-notifier=false" > /squid/.npmrc
+RUN npm i -g @subsquid/commands && mv $(which squid-commands) /usr/local/bin/sqd
+ENV PROCESSOR_PROMETHEUS_PORT 3000

--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
   "name": "squid-evm-template",
   "private": true,
   "scripts": {
+    "generateProductionConstants": "NETWORK_ADDRESS='0x78163f593D1Fa151B4B7cacD146586aD2b686294' node ./utils/generateConstantsFile.js > ./src/utils/constants.ts",
+    "generateQAConstants": "NETWORK_ADDRESS='0x6a05DD32860C1b5351B97b4eCAAbFbc60edb102f' node ./src/utils/generateConstantsFile.js > ./src/utils/constants.ts",
     "build": "rm -rf lib && tsc"
   },
   "dependencies": {

--- a/src/handlers/domains/index.ts
+++ b/src/handlers/domains/index.ts
@@ -108,8 +108,6 @@ export const handleDomainAdded = async (
 
   const args = event.args.toObject();
 
-  const colonyContract = new ColonyContract(context, log.block, log.address);
-
   /*
    * @TODO Properly fetch the domain count
    * As-is this won't work if multiple domains (within the same colony) are created
@@ -118,6 +116,7 @@ export const handleDomainAdded = async (
    */
   let domainChainId = args.domainId;
   if (!domainChainId) {
+    const colonyContract = new ColonyContract(context, log.block, log.address);
     domainChainId = await colonyContract.getDomainCount();
   }
 

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -2,8 +2,10 @@ import {lookupArchive} from '@subsquid/archive-registry'
 
 import { events as colonyNetworkEvents } from './abi/IColonyNetwork';
 import { events as colonyEvents } from './abi/IColony';
+import { events as votingReputationEvents } from './abi/VotingReputation';
+import { events as oneTxPaymentEvents } from './abi/OneTxPayment';
 
-import { COLONY_NETWORK_ADDRESS } from './utils/constants';
+import { COLONY_NETWORK_ADDRESS, PRELOADED_COLONIES, PRELOAD_HEIGHT, PRELOADED_ONE_TX_PAYMENT, PRELOADED_VOTING_REPUTATION } from './utils/constants';
 
 import {
     BlockHeader,
@@ -31,9 +33,9 @@ export const processor = new EvmBatchProcessor()
       // Must be set for RPC ingestion (https://docs.subsquid.io/evm-indexing/evm-processor/)
       // OR to enable contract state queries (https://docs.subsquid.io/evm-indexing/query-state/)
       // chain: 'https://xdai.colony.io/rpcarchive/',
-    chain: 'http://localhost:8545/'
+      chain: 'http://localhost:8545/'
   })
-  .setFinalityConfirmation(1)
+  .setFinalityConfirmation(200)
   .setBlockRange({
       from: 1,
   })
@@ -44,8 +46,45 @@ export const processor = new EvmBatchProcessor()
     ],
   })
   .addLog({
+    range: {
+      from: PRELOAD_HEIGHT + 1,
+    },
     topic0: [
       ...Object.values(colonyEvents).map(entry => entry.topic),
+    ],
+  })
+  .addLog({
+    address: PRELOADED_COLONIES,
+    topic0: [
+      ...Object.values(colonyEvents).map(entry => entry.topic),
+    ],
+  })
+  .addLog({
+    range: {
+      from: PRELOAD_HEIGHT + 1,
+    },
+    topic0: [
+      ...Object.values(oneTxPaymentEvents).map(entry => entry.topic),
+    ],
+  })
+  .addLog({
+    address: PRELOADED_ONE_TX_PAYMENT,
+    topic0: [
+      ...Object.values(oneTxPaymentEvents).map(entry => entry.topic),
+    ],
+  })
+  .addLog({
+    range: {
+      from: PRELOAD_HEIGHT + 1,
+    },
+    topic0: [
+      ...Object.values(votingReputationEvents).map(entry => entry.topic),
+    ],
+  })
+  .addLog({
+    address: PRELOADED_VOTING_REPUTATION,
+    topic0: [
+      ...Object.values(votingReputationEvents).map(entry => entry.topic),
     ],
   })
   .setFields({

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,1 +1,6 @@
 export const COLONY_NETWORK_ADDRESS = '0x5CC4a96B08e8C88f2c6FC5772496FeD9666e4D1F'.toLowerCase();
+
+export const PRELOAD_HEIGHT = 1;
+export const PRELOADED_COLONIES = [];
+export const PRELOADED_ONE_TX_PAYMENT = [];
+export const PRELOADED_VOTING_REPUTATION = [];

--- a/src/utils/generateConstantsFile.js
+++ b/src/utils/generateConstantsFile.js
@@ -1,0 +1,68 @@
+const ethers = require("ethers");
+
+const { ABI_JSON: NetworkAbi } = require("../../lib/abi/IColonyNetwork.abi.js");
+
+const COLONY_NETWORK_ADDRESS = process.env.NETWORK_ADDRESS || "0x78163f593D1Fa151B4B7cacD146586aD2b686294";
+const BLOCK_PAGE_SIZE = 1_000_000;
+const ONE_TX_PAYMENT = ethers.solidityPackedKeccak256(["string"], ["OneTxPayment"])
+const VOTING_REPUTATION = ethers.solidityPackedKeccak256(["string"], ["VotingReputation"])
+
+async function getAllExtensionInstallations(blockNumber, networkContract, oldNetworkContract, extensionIdentifier) {
+  const filter = networkContract.filters.ExtensionInstalled(extensionIdentifier);
+  const oldFilter = oldNetworkContract.filters.ExtensionInstalled(
+    extensionIdentifier
+  );
+
+  // const events = await p.getLogs(filter);
+  let extensions = []
+  let fromBlock = 1;
+  let toBlock = BLOCK_PAGE_SIZE;
+  while (toBlock < blockNumber) {
+    events = await networkContract.queryFilter(filter, fromBlock, toBlock);
+    oldEvents = await oldNetworkContract.queryFilter(oldFilter, fromBlock, toBlock);
+    events = events.concat(oldEvents);
+    for (let i = 0; i < events.length; i++) {
+      const e = events[i]; 
+      // Get the address of the installed extension
+      const extensionAddress = await networkContract.getExtensionInstallation(extensionIdentifier, e.args.colony, { blockTag: e.blockNumber })
+      extensions.push(extensionAddress);
+    }
+
+    fromBlock = toBlock + 1;
+    toBlock = Math.min(blockNumber, toBlock + BLOCK_PAGE_SIZE);
+  }
+
+  return extensions;
+}
+
+async function main() {
+  const p = new ethers.JsonRpcProvider("https://xdai.colony.io/rpcarchive/");
+  const cn = new ethers.Contract(COLONY_NETWORK_ADDRESS, NetworkAbi, p);
+  const blockNumber = await p.getBlockNumber();
+  const nColonies = await cn.getColonyCount({ blockTag: blockNumber });
+  const latest = await cn.getColony(nColonies);
+  const colonies = [];
+  const networkContract = new ethers.Contract(COLONY_NETWORK_ADDRESS, NetworkAbi, p);
+
+  const oldAbi = ["event ExtensionInstalled(bytes32 indexed extensionId, uint256 version, address indexed colony)"];
+  const oldInterface = new ethers.Interface(oldAbi);
+  const oldNetworkContract = new ethers.Contract(COLONY_NETWORK_ADDRESS, oldInterface, p);
+
+  for (let i = 1; i <= nColonies; i += 1) {
+    const colonyAddress = await cn.getColony(i); // No blockTag needed here -
+    // it's a constant, and I think is slightly quicker if we omit
+    // const colony = new ethers.Contract(colonyAddress, ColonyAbi, p);
+    colonies.push(colonyAddress);
+  }
+  // Get all onetxpayments that have ever been installed
+  const onetxpayments = await getAllExtensionInstallations(blockNumber, networkContract, oldNetworkContract, ONE_TX_PAYMENT);
+  const votingreputations = await getAllExtensionInstallations(blockNumber, networkContract, oldNetworkContract, VOTING_REPUTATION);
+
+  console.log(`export const COLONY_NETWORK_ADDRESS = '${COLONY_NETWORK_ADDRESS.toLowerCase()}';`);
+  console.log(`export const PRELOAD_HEIGHT = ${blockNumber}`);
+  console.log(`export const PRELOADED_COLONIES = ['${colonies.join("','")}']`);
+  console.log(`export const PRELOADED_ONE_TX_PAYMENT = ['${onetxpayments.join("','")}']`);
+  console.log(`export const PRELOADED_VOTING_REPUTATION = ['${votingreputations.join("','")}']`);
+}
+
+main();


### PR DESCRIPTION
All sorts, here

* Removed unnecessary RPC requests when we can go to the database instead, as going to the database is a lot faster.
* Added the Dockerfile we use (from [the docs](https://docs.subsquid.io/deploy-squid/self-hosting/))
* Changed the processor config to use the recommended pattern to improve syncing speed with [factory contracts](https://docs.subsquid.io/evm-indexing/factory-contracts/), and a script to generate the necessary constants.
* Dealt with 'duplicate' motions from when we had a [storage layout issue](https://github.com/JoinColony/colonyNetwork/pull/1081) with the voting reputation extension, which caused IDs to be reused. The duplicates are ignored, mirroring what we did on-chain.
* Added stricter guards to only handle events from contracts we know about.